### PR TITLE
provide user-friendly message when users type terratorch iterate

### DIFF
--- a/benchmark/backbone_benchmark.py
+++ b/benchmark/backbone_benchmark.py
@@ -221,10 +221,10 @@ def benchmark_backbone(
     base = Path(storage_uri).parents[0]
     PATH_TO_JOB_TRACKING = base / "job_progress_tracking"
     REPEATED_EXP_FOLDER = base / "repeated_exp_output_csv"
-    
+
     # https://mlflow.org/docs/latest/ml/tracking/system-metrics/#using-the-environment-variable-to-control-system-metrics-logging
     if os.getenv("MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING") is None:
-        os.environ["MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING"] = "true" 
+        os.environ["MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING"] = "true"
 
     if logger is None:
         logger = get_logger(log_folder=str(base / "job_logs"))

--- a/benchmark/config_util/build_geobench_configs.py
+++ b/benchmark/config_util/build_geobench_configs.py
@@ -228,15 +228,17 @@ def generate_iterate_config(
     prompt='Prefix of the config filename, e.g., my-config-',
     help='Prefix of the config filename',
 )
-def generate_tt_iterate_config(input_dir: str, output_dir: str, template: str, prefix: str):
+def generate_tt_iterate_config(
+    input_dir: str, output_dir: str, template: str, prefix: str
+):
     directory_path = Path(input_dir)
     assert directory_path.exists()
     assert directory_path.is_dir
-    
+
     template_path = Path(template)
     assert template_path.exists()
     assert template_path.is_file
-    
+
     output_path = Path(output_dir)
     assert output_path.exists()
     assert output_path.is_dir

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -1,7 +1,9 @@
+from jsonargparse import Namespace
 import logging
 from pathlib import Path
 from typing import Any, List
 from jsonargparse import ArgumentParser
+import pandas as pd
 from benchmark.backbone_benchmark import benchmark_backbone
 from benchmark.benchmark_types import Defaults, Task
 from benchmark.repeat_best_experiment import rerun_best_from_backbone
@@ -12,8 +14,126 @@ from benchmark.utils import (
 )
 
 
+def _summarize(
+    config_init: Namespace,
+    hpo: bool,
+    repeat: bool,
+    storage_uri: str,
+    logger: logging.RootLogger,
+) -> pd.DataFrame:
+    """only summarize results from multiple experiments
+
+    Args:
+        config_init (Namespace): _description_
+        hpo (bool): flag that indicates whether to run hpo
+        repeat (bool): flag that indicates whether to repeat best experiment
+        storage_uri (str): path to directory in which results will be stored
+        logger (logging.RootLogger): logger variable
+
+    Returns:
+        _type_: _description_
+    """
+    assert (
+        hpo is False and repeat is False
+    ), f"Error! both {repeat=} and {hpo=} must be False when summarizing results from multiple experiments."
+
+    list_of_experiment_names = config_init.list_of_experiment_names
+    assert isinstance(
+        list_of_experiment_names, list
+    ), f"Error! {list_of_experiment_names=} is not a list"
+    for exp in list_of_experiment_names:
+        assert isinstance(exp, str), f"Error! {exp=} is not a str"
+
+    task_names = config_init.task_names
+    assert isinstance(task_names, list), f"Error! {task_names=} is not a list"
+    for t in task_names:
+        assert isinstance(t, str), f"Error! {t=} is not a str"
+
+    task_metrics = config_init.task_metrics
+    assert isinstance(task_metrics, list), f"Error! {task_metrics=} is not a list"
+    for t in task_metrics:
+        assert isinstance(t, str), f"Error! {t=} is not a str"
+
+    benchmark_name = config_init.benchmark_name
+    assert isinstance(benchmark_name, str), f"Error! {benchmark_name=} is not a str"
+
+    run_repetitions = config_init.run_repetitions
+    assert (
+        isinstance(run_repetitions, int) and run_repetitions > 0
+    ), f"Error! {run_repetitions=} is invalid"
+    # get results and parameters from mlflow logs
+    results_and_parameters = get_results_and_parameters(
+        benchmark_name=benchmark_name,
+        storage_uri=storage_uri,
+        logger=logger,
+        experiments=list_of_experiment_names,
+        task_names=task_names,
+        num_repetitions=run_repetitions,
+        task_metrics=task_metrics,
+    )
+    return results_and_parameters
+
+
+def _repeat_experiment(
+    config_init: Namespace,
+    storage_uri: str,
+    experiment_name: str,
+    parent_run_id: str,
+    defaults: Defaults,
+    tasks: list[Task],
+    optimization_space: dict,
+    run_repetitions: int,
+    save_models: bool,
+    report_on_best_val: bool,
+    logger: logging.RootLogger,
+):
+    """repeat best experiments
+
+    Args:
+        config_init (Namespace): _description_
+        storage_uri (str): _description_
+        experiment_name (str): _description_
+        parent_run_id (str): _description_
+        defaults (Defaults): _description_
+        tasks (list[Task]): _description_
+        optimization_space (dict): _description_
+        run_repetitions (int): _description_
+        save_models (bool): _description_
+        report_on_best_val (bool): _description_
+        logger (logging.RootLogger): _description_
+
+    Returns:
+        _type_: _description_
+    """
+    output: str | None = config_init.output_path
+    if output is None:
+        storage_uri_path = Path(storage_uri)
+        assert (
+            storage_uri_path.exists() and storage_uri_path.is_dir()
+        ), f"Error! Unable to create new output_path based on storage_uri_path because the latter does not exist: {storage_uri_path}"
+        output_path = storage_uri_path.parents[0] / "repeated_exp_output_csv"
+        output_path.mkdir(parents=True, exist_ok=True)
+        output_path = output_path / f"{experiment_name}_repeated_exp_mlflow.csv"
+        output = str(output_path)
+
+    logger.info("Rerun best experiments...")
+    rerun_best_from_backbone(
+        logger=logger,
+        parent_run_id=parent_run_id,
+        output_path=output_path,
+        defaults=defaults,
+        tasks=tasks,
+        experiment_name=experiment_name,
+        storage_uri=storage_uri,
+        optimization_space=optimization_space,
+        run_repetitions=run_repetitions,
+        save_models=save_models,
+        report_on_best_val=report_on_best_val,
+    )
+
+
 def main():
-    print("Running terratorch-iterate...")
+
     parser = ArgumentParser()
 
     parser.add_argument('--defaults', type=Defaults)  # to ignore model
@@ -29,7 +149,7 @@ def main():
     parser.add_argument("--parent_run_id", type=str)
     parser.add_argument("--output_path", type=str)
     parser.add_argument("--logger", type=str)
-    parser.add_argument("--config", action="config")
+    parser.add_argument("--config", action="store")
     parser.add_argument('--custom_modules_path', type=str)
     parser.add_argument('--report_on_best_val', type=bool, default=True)
     parser.add_argument('--test_models', type=bool, default=False)
@@ -52,181 +172,146 @@ def main():
 
     args = parser.parse_args()
     paths: List[Any] = args.config
-    path = paths[0]
-    config = parser.parse_path(path)
-    config_init = parser.instantiate_classes(config)
+    if paths is not None:
+        assert isinstance(paths, list), f"Error! Unexpected config type: {paths}"
+        assert len(paths) > 0, f"Error! empty list of config"
+        path = paths[0]
+        config = parser.parse_path(path)
+        config_init: Namespace = parser.instantiate_classes(config)
 
-    summarize = args.summarize
-    assert isinstance(summarize, bool), f"Error! {summarize=} is not a bool"
-    repeat = args.repeat
-    assert isinstance(repeat, bool), f"Error! {repeat=} is not a bool"
-    hpo = args.hpo
-    assert isinstance(hpo, bool), f"Error! {hpo=} is not a bool"
+        summarize: bool = args.summarize
+        assert isinstance(summarize, bool), f"Error! {summarize=} is not a bool"
+        repeat = args.repeat
+        assert isinstance(repeat, bool), f"Error! {repeat=} is not a bool"
+        hpo = args.hpo
+        assert isinstance(hpo, bool), f"Error! {hpo=} is not a bool"
 
-    storage_uri = config_init.storage_uri
-    assert isinstance(storage_uri, str), f"Error! {storage_uri=} is not a str"
-    logger_path = config_init.logger
-    if logger_path is None:
-        storage_uri_path = Path(storage_uri)
-        logger = get_logger(log_folder=f"{str(storage_uri_path.parents[0])}/job_logs")
-    else:
-        logging.config.fileConfig(fname=logger_path, disable_existing_loggers=False)
-        logger = logging.getLogger("terratorch-iterate")
-
-    # only summarize results from multiple experiments
-    if summarize:
-        assert (
-            hpo is False and repeat is False
-        ), f"Error! both {repeat=} and {hpo=} must be False when summarizing results from multiple experiments."
-
-        list_of_experiment_names = config_init.list_of_experiment_names
-        assert isinstance(
-            list_of_experiment_names, list
-        ), f"Error! {list_of_experiment_names=} is not a list"
-        for exp in list_of_experiment_names:
-            assert isinstance(exp, str), f"Error! {exp=} is not a str"
-
-        task_names = config_init.task_names
-        assert isinstance(task_names, list), f"Error! {task_names=} is not a list"
-        for t in task_names:
-            assert isinstance(t, str), f"Error! {t=} is not a str"
-
-        task_metrics = config_init.task_metrics
-        assert isinstance(task_metrics, list), f"Error! {task_metrics=} is not a list"
-        for t in task_metrics:
-            assert isinstance(t, str), f"Error! {t=} is not a str"
-
-        benchmark_name = config_init.benchmark_name
-        assert isinstance(benchmark_name, str), f"Error! {benchmark_name=} is not a str"
-
-        run_repetitions = config_init.run_repetitions
-        assert (
-            isinstance(run_repetitions, int) and run_repetitions > 0
-        ), f"Error! {run_repetitions=} is invalid"
-        # get results and parameters from mlflow logs
-        results_and_parameters = get_results_and_parameters(
-            benchmark_name=benchmark_name,
-            storage_uri=storage_uri,
-            logger=logger,
-            experiments=list_of_experiment_names,
-            task_names=task_names,
-            num_repetitions=run_repetitions,
-            task_metrics=task_metrics,
-        )
-        return
-
-    # optimize hyperparameters and/or do repeated runs for single experiments
-    assert (
-        hpo is True or repeat is True
-    ), f"Error! either {repeat=} or {hpo=} must be True"
-    parent_run_id = args.parent_run_id
-    if parent_run_id is not None:
-        assert isinstance(parent_run_id, str), f"Error! {parent_run_id=} is not a str"
-
-    # validate the objects
-    experiment_name = config_init.experiment_name
-    assert isinstance(experiment_name, str), f"Error! {experiment_name=} is not a str"
-    run_name = config_init.run_name
-    if run_name is not None:
-        assert isinstance(run_name, str), f"Error! {run_name=} is not a str"
-    # validate defaults
-    defaults = config_init.defaults
-    assert isinstance(defaults, Defaults), f"Error! {defaults=} is not a Defaults"
-
-    tasks = config_init.tasks
-    assert isinstance(tasks, list), f"Error! {tasks=} is not a list"
-    for t in tasks:
-        assert isinstance(t, Task), f"Error! {t=} is not a Task"
-        # if there is not specific terratorch_task specified, then use default terratorch_task
-        if t.terratorch_task is None:
-            t.terratorch_task = defaults.terratorch_task
-    # defaults.trainer_args["max_epochs"] = 5
-
-    optimization_space = config_init.optimization_space
-    assert isinstance(
-        optimization_space, dict
-    ), f"Error! {optimization_space=} is not a dict"
-
-    # ray_storage_path is optional
-    ray_storage_path = config_init.ray_storage_path
-    if ray_storage_path is not None:
-        assert isinstance(
-            ray_storage_path, str
-        ), f"Error! {ray_storage_path=} is not a str"
-
-    n_trials = config_init.n_trials
-    assert isinstance(n_trials, int) and n_trials > 0, f"Error! {n_trials=} is invalid"
-    run_repetitions = config_init.run_repetitions
-
-    report_on_best_val = config_init.report_on_best_val
-    assert isinstance(
-        report_on_best_val, bool
-    ), f"Error! {ray_storage_path=} is not a bool"
-
-    save_models = config_init.save_models
-    assert isinstance(save_models, bool), f"Error! {save_models=} is not a bool"
-
-    test_models = config_init.test_models
-    assert isinstance(test_models, bool), f"Error! {test_models=} is not a bool"
-
-    bayesian_search = config_init.bayesian_search
-    assert isinstance(bayesian_search, bool), f"Error! {bayesian_search=} is not a bool"
-
-    # custom_modules_path is optional
-    custom_modules_path = config_init.custom_modules_path
-    if custom_modules_path is not None:
-        assert isinstance(
-            custom_modules_path, str
-        ), f"Error! {custom_modules_path=} is not a str"
-        import_custom_modules(logger=logger, custom_modules_path=custom_modules_path)
-
-    if repeat and not hpo:
-        output = config_init.output_path
-        if output is None:
+        storage_uri = config_init.storage_uri
+        assert isinstance(storage_uri, str), f"Error! {storage_uri=} is not a str"
+        logger_path = config_init.logger
+        if logger_path is None:
             storage_uri_path = Path(storage_uri)
-            assert (
-                storage_uri_path.exists() and storage_uri_path.is_dir()
-            ), f"Error! Unable to create new output_path based on storage_uri_path because the latter does not exist: {storage_uri_path}"
-            output_path = storage_uri_path.parents[0] / "repeated_exp_output_csv"
-            output_path.mkdir(parents=True, exist_ok=True)
-            output_path = output_path / f"{experiment_name}_repeated_exp_mlflow.csv"
-            output = str(output_path)
+            logger = get_logger(
+                log_folder=f"{str(storage_uri_path.parents[0])}/job_logs"
+            )
+        else:
+            logging.config.fileConfig(fname=logger_path, disable_existing_loggers=False)
+            logger = logging.getLogger("terratorch-iterate")
 
-        logger.info("Rerun best experiments...")
-        rerun_best_from_backbone(
-            logger=logger,
-            parent_run_id=parent_run_id,
-            output_path=str(output_path),
-            defaults=defaults,
-            tasks=tasks,
-            experiment_name=experiment_name,
-            storage_uri=storage_uri,
-            optimization_space=optimization_space,
-            run_repetitions=run_repetitions,
-            save_models=save_models,
-            report_on_best_val=report_on_best_val,
-        )
-    else:
-        if not repeat and hpo:
-            run_repetitions = 0
+        # only summarize results from multiple experiments
+        if summarize:
+            return _summarize(
+                config_init=config_init,
+            )
 
-        # run_repetitions is an optional parameter
-        benchmark_backbone(
-            defaults=defaults,
-            tasks=tasks,
-            experiment_name=experiment_name,
-            storage_uri=storage_uri,
-            ray_storage_path=ray_storage_path,
-            run_name=run_name,
-            optimization_space=optimization_space,
-            n_trials=n_trials,
-            run_repetitions=run_repetitions,
-            save_models=save_models,
-            report_on_best_val=report_on_best_val,
-            test_models=test_models,
-            bayesian_search=bayesian_search,
-            logger=logger,
-        )
+        # optimize hyperparameters and/or do repeated runs for single experiments
+        assert (
+            hpo is True or repeat is True
+        ), f"Error! either {repeat=} or {hpo=} must be True"
+        parent_run_id = args.parent_run_id
+        if parent_run_id is not None:
+            assert isinstance(
+                parent_run_id, str
+            ), f"Error! {parent_run_id=} is not a str"
+
+        # validate the objects
+        experiment_name = config_init.experiment_name
+        assert isinstance(
+            experiment_name, str
+        ), f"Error! {experiment_name=} is not a str"
+        run_name = config_init.run_name
+        if run_name is not None:
+            assert isinstance(run_name, str), f"Error! {run_name=} is not a str"
+        # validate defaults
+        defaults = config_init.defaults
+        assert isinstance(defaults, Defaults), f"Error! {defaults=} is not a Defaults"
+
+        tasks = config_init.tasks
+        assert isinstance(tasks, list), f"Error! {tasks=} is not a list"
+        for t in tasks:
+            assert isinstance(t, Task), f"Error! {t=} is not a Task"
+            # if there is not specific terratorch_task specified, then use default terratorch_task
+            if t.terratorch_task is None:
+                t.terratorch_task = defaults.terratorch_task
+        # defaults.trainer_args["max_epochs"] = 5
+
+        optimization_space = config_init.optimization_space
+        assert isinstance(
+            optimization_space, dict
+        ), f"Error! {optimization_space=} is not a dict"
+
+        # ray_storage_path is optional
+        ray_storage_path = config_init.ray_storage_path
+        if ray_storage_path is not None:
+            assert isinstance(
+                ray_storage_path, str
+            ), f"Error! {ray_storage_path=} is not a str"
+
+        n_trials = config_init.n_trials
+        assert (
+            isinstance(n_trials, int) and n_trials > 0
+        ), f"Error! {n_trials=} is invalid"
+        run_repetitions = config_init.run_repetitions
+
+        report_on_best_val = config_init.report_on_best_val
+        assert isinstance(
+            report_on_best_val, bool
+        ), f"Error! {ray_storage_path=} is not a bool"
+
+        save_models = config_init.save_models
+        assert isinstance(save_models, bool), f"Error! {save_models=} is not a bool"
+
+        test_models = config_init.test_models
+        assert isinstance(test_models, bool), f"Error! {test_models=} is not a bool"
+
+        bayesian_search = config_init.bayesian_search
+        assert isinstance(
+            bayesian_search, bool
+        ), f"Error! {bayesian_search=} is not a bool"
+
+        # custom_modules_path is optional
+        custom_modules_path = config_init.custom_modules_path
+        if custom_modules_path is not None:
+            assert isinstance(
+                custom_modules_path, str
+            ), f"Error! {custom_modules_path=} is not a str"
+            import_custom_modules(
+                logger=logger, custom_modules_path=custom_modules_path
+            )
+
+        if repeat and not hpo:
+            _repeat_experiment(
+                config_init=config_init,
+                storage_uri=storage_uri,
+                experiment_name=experiment_name,
+                defaults=defaults,
+                tasks=tasks,
+                optimization_space=optimization_space,
+                run_repetitions=run_repetitions,
+                save_models=save_models,
+                logger=logger,
+            )
+        else:
+            if not repeat and hpo:
+                run_repetitions = 0
+
+            # run_repetitions is an optional parameter
+            benchmark_backbone(
+                defaults=defaults,
+                tasks=tasks,
+                experiment_name=experiment_name,
+                storage_uri=storage_uri,
+                ray_storage_path=ray_storage_path,
+                run_name=run_name,
+                optimization_space=optimization_space,
+                n_trials=n_trials,
+                run_repetitions=run_repetitions,
+                save_models=save_models,
+                report_on_best_val=report_on_best_val,
+                test_models=test_models,
+                bayesian_search=bayesian_search,
+                logger=logger,
+            )
 
 
 if __name__ == "__main__":

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -172,7 +172,16 @@ def main():
 
     args = parser.parse_args()
     paths: List[Any] = args.config
-    if paths is not None:
+    if paths is None:
+        msg = """
+        usage: terratorch [-h] [--defaults CONFIG] [--defaults.trainer_args TRAINER_ARGS] [--defaults.terratorch_task TERRATORCH_TASK] [--optimization_space OPTIMIZATION_SPACE] [--experiment_name EXPERIMENT_NAME]
+                  [--run_name RUN_NAME] [--save_models {true,false}] [--storage_uri STORAGE_URI] [--ray_storage_path RAY_STORAGE_PATH] [--n_trials N_TRIALS] [--run_repetitions RUN_REPETITIONS] [--tasks TASKS]
+                  [--parent_run_id PARENT_RUN_ID] [--output_path OUTPUT_PATH] [--logger LOGGER] [--config CONFIG] [--custom_modules_path CUSTOM_MODULES_PATH] [--report_on_best_val {true,false}]
+                  [--test_models {true,false}] [--bayesian_search {true,false}] [--hpo] [--repeat] [--summarize] [--list_of_experiment_names LIST_OF_EXPERIMENT_NAMES] [--task_names TASK_NAMES]
+                  [--task_metrics TASK_METRICS] [--benchmark_name BENCHMARK_NAME]
+        """
+        print(msg)
+    else:
         assert isinstance(paths, list), f"Error! Unexpected config type: {paths}"
         assert len(paths) > 0, f"Error! empty list of config"
         path = paths[0]

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -174,11 +174,8 @@ def main():
     paths: List[Any] = args.config
     if paths is None:
         msg = """
-        usage: terratorch [-h] [--defaults CONFIG] [--defaults.trainer_args TRAINER_ARGS] [--defaults.terratorch_task TERRATORCH_TASK] [--optimization_space OPTIMIZATION_SPACE] [--experiment_name EXPERIMENT_NAME]
-                  [--run_name RUN_NAME] [--save_models {true,false}] [--storage_uri STORAGE_URI] [--ray_storage_path RAY_STORAGE_PATH] [--n_trials N_TRIALS] [--run_repetitions RUN_REPETITIONS] [--tasks TASKS]
-                  [--parent_run_id PARENT_RUN_ID] [--output_path OUTPUT_PATH] [--logger LOGGER] [--config CONFIG] [--custom_modules_path CUSTOM_MODULES_PATH] [--report_on_best_val {true,false}]
-                  [--test_models {true,false}] [--bayesian_search {true,false}] [--hpo] [--repeat] [--summarize] [--list_of_experiment_names LIST_OF_EXPERIMENT_NAMES] [--task_names TASK_NAMES]
-                  [--task_metrics TASK_METRICS] [--benchmark_name BENCHMARK_NAME]
+        Error: config argument has not been passed
+        usage: terratorch [-h] [--hpo] [--repeat] [--summarize] [--config CONFIG] 
         """
         print(msg)
     else:

--- a/benchmark/model_fitting.py
+++ b/benchmark/model_fitting.py
@@ -313,13 +313,17 @@ def launch_training(
             ["metric_name", "step"], verify_integrity=True
         )
         series_val_metrics = df_val_metrics["value"]
-        assert metric in series_val_metrics, f"Error! {metric} is not in {series_val_metrics}"
+        assert (
+            metric in series_val_metrics
+        ), f"Error! {metric} is not in {series_val_metrics}"
         if direction == "max":
             best_step = series_val_metrics[metric].idxmax()
         elif direction == "min":
             best_step = series_val_metrics[metric].idxmin()
         else:
-            raise Exception(f"Error! Direction must be either `max` or `min` but got {direction}")
+            raise Exception(
+                f"Error! Direction must be either `max` or `min` but got {direction}"
+            )
 
         for val_metric_name in val_metrics_names:
             mlflow.log_metric(

--- a/run_tests.py
+++ b/run_tests.py
@@ -6,6 +6,7 @@ import click
 
 # rm geobench_v1_prithvi* && bsub -e ~/geobench_v1_prithvi.err -o ~/geobench_v1_prithvi.out -M 40G -gpu "num=1/task:mode=exclusive_process:gmodel=NVIDIAA100_SXM4_80GB" terratorch iterate --hpo --config configs/geobench_v1_prithvi.yaml
 
+
 @click.command()
 @click.option('--test_id', default=None, help='test ID')
 def run_tests(test_id: Optional[str] = None):

--- a/tests/test_build_geobench_configs.py
+++ b/tests/test_build_geobench_configs.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import pytest
 import yaml

--- a/tests/unit/test_tasktypeenum.py
+++ b/tests/unit/test_tasktypeenum.py
@@ -2,18 +2,24 @@ from benchmark.benchmark_types import TaskTypeEnum
 import pytest
 from terratorch.tasks.base_task import TerraTorchTask
 from terratorch.tasks.classification_tasks import ClassificationTask
-from terratorch.tasks.multilabel_classification_tasks import MultiLabelClassificationTask
+from terratorch.tasks.multilabel_classification_tasks import (
+    MultiLabelClassificationTask,
+)
 from terratorch.tasks.segmentation_tasks import SemanticSegmentationTask
 from terratorch.tasks.regression_tasks import PixelwiseRegressionTask
 from terratorch.tasks.object_detection_task import ObjectDetectionTask
 
-@pytest.mark.parametrize("task_type, expected_class", [
-    ("classification", ClassificationTask),
-    ("segmentation", SemanticSegmentationTask),
-    ("multilabel_classification", MultiLabelClassificationTask),
-    ("regression", PixelwiseRegressionTask),
-    ("object_detection", ObjectDetectionTask),
-])
+
+@pytest.mark.parametrize(
+    "task_type, expected_class",
+    [
+        ("classification", ClassificationTask),
+        ("segmentation", SemanticSegmentationTask),
+        ("multilabel_classification", MultiLabelClassificationTask),
+        ("regression", PixelwiseRegressionTask),
+        ("object_detection", ObjectDetectionTask),
+    ],
+)
 def test_get_class_from_enum(task_type: str, expected_class: TerraTorchTask):
     t = TaskTypeEnum(value=task_type)
     type_class = t.get_class_from_enum()


### PR DESCRIPTION
when users type `terratorch iterate`, it raises an type error. The expected behavior is to show a user-friendly message on how to use iterate.
this PR closes issue #40  and also includes a minor refactoring.